### PR TITLE
Changed dom-selector to support multiple elements with same ID

### DIFF
--- a/skin/frontend/base/default/wigman/ajaxswatches/js/swatches-extend.js
+++ b/skin/frontend/base/default/wigman/ajaxswatches/js/swatches-extend.js
@@ -82,7 +82,9 @@ ConfigurableMediaImages.ajaxLoadSwatchList = function(){
 
 							$j(data.swatches).each(function(key, swatchObj){
 								i++;
-								var parentLi = $j('#product-collection-image-'+swatchObj['id']).parentsUntil('ul,ol');
+								// It's not valid HTML having multiple elements with same ID
+								// but in some cases there are same products on one page (e.g. top seller slider)
+								var parentLi = $j('[id="product-collection-image-' + swatchObj['id'] + '"]').parentsUntil('ul,ol');
 								
 								//$j(swatchObj['value']).insertAfter(parentLi.find('.product-name'));
 								parentLi.find('.swatch-loader').replaceWith($j(swatchObj['value']));


### PR DESCRIPTION
If you have multiple product grids on one page for example product slider and category list it'll only update the first matched image element so the loading gif won't disappear.

I know it's not valid HTML having multiple elements with same ID :)
