### PR TITLE
Remove existing configurable swatch list

### DIFF
--- a/skin/frontend/base/default/wigman/ajaxswatches/js/swatches-extend.js
+++ b/skin/frontend/base/default/wigman/ajaxswatches/js/swatches-extend.js
@@ -85,7 +85,12 @@ ConfigurableMediaImages.ajaxLoadSwatchList = function(){
 								// It's not valid HTML having multiple elements with same ID
 								// but in some cases there are same products on one page (e.g. top seller slider)
 								var parentLi = $j('[id="product-collection-image-' + swatchObj['id'] + '"]').parentsUntil('ul,ol');
-								
+
+								// remove configurable-swatch-list if already exists
+								if(parentLi.find('.configurable-swatch-list').length) {
+									parentLi.find('.configurable-swatch-list').remove();
+								}
+
 								//$j(swatchObj['value']).insertAfter(parentLi.find('.product-name'));
 								parentLi.find('.swatch-loader').replaceWith($j(swatchObj['value']));
 								if(i == items.length){


### PR DESCRIPTION
In my case I've got a slider with topsellers and a product grid below. At the first call both lists will be updated by AjaxSwatches. If you're using the ajax pagination for product list you'll only get the product grid of selected page. After that AjaxSwatches will reload swatches list for all products on current page and insert a second list for topseller-slider. To prevent this behavior I delete out of date swatches lists before inserting if already exists.
