### PR TITLE
ChildrenAttributeMapping for multiple products and options

### DIFF
--- a/app/code/community/Wigman/AjaxSwatches/Helper/Mediafallback.php
+++ b/app/code/community/Wigman/AjaxSwatches/Helper/Mediafallback.php
@@ -111,8 +111,6 @@ class Wigman_AjaxSwatches_Helper_Mediafallback extends Mage_ConfigurableSwatches
                         $mapping[$optionLabel] = array(
                             'product_ids' => array(),
                         );
-                    } else {
-	                    $mapping[$optionLabel] = array();
                     }
 
                     $mapping[$optionLabel]['product_ids'][] = $childProduct->getId();


### PR DESCRIPTION
For example you have an USB-Stick defined as a configurable product:

You've got following options:
color = red, blue
capacity = 1gb, 2gb

and linked simple products:
ID:1 USB-Stick (red, 1gb)
ID:2 USB-Stick (red, 2gb)
ID:3 USB-Stick (blue, 1gb)
ID:4 USB-Stick (blue, 2gb)

Mapping will look like:

``` php
$mapping = array(
'red' => array('product_ids' => 2),
'blue' => array('product_ids' => 4),
'1gb' => array('product_ids' => 3),
'2gb' => array('product_ids' => 4),
);
```

If you're now selecting color "red" in frontend one compatible product (ID:2) will found. If you now try to select capacity "2GB" no compatible product will found because you're overwriting it with an empty array. So ajax call won't be triggered..

For this example mapping should look like:

``` php
$mapping = array(
'red' => array('product_ids' => 1, 2),
'blue' => array('product_ids' => 3, 4),
'1gb' => array('product_ids' => 1,3),
'2gb' => array('product_ids' => 2, 4),
);
```

Also there is a bug in Magento's **product-media.js:31 arrayIntersect()** if you have more product ids for second attribute option. I've found this [patch](https://gist.github.com/splendidinternet/0db39b406264024d5c06), which works fine for me.
