### PR TITLE
Refactor to let parent's getJsonConfig() intact :

### DIFF
--- a/app/code/community/Wigman/AjaxSwatches/Block/Catalog/Product/View/Type/Configurable.php
+++ b/app/code/community/Wigman/AjaxSwatches/Block/Catalog/Product/View/Type/Configurable.php
@@ -1,5 +1,5 @@
 <?php
-/**
+/*/**
  * Magento
  *
  * NOTICE OF LICENSE
@@ -36,167 +36,60 @@
  * Wigman changes: We're adding attribute sorting to the mix! See comments below.
  *
  */
-class Wigman_AjaxSwatches_Block_Catalog_Product_View_Type_Configurable extends Mage_Catalog_Block_Product_View_Type_Configurable
+class Wigman_AjaxSwatches_Block_Catalog_Product_View_Type_Configurable extends Wigman_AjaxSwatches_Block_Catalog_Product_View_Type_Configurable_Abstract
 {
+
+    protected $_optionLabels = null;
+
     public function getJsonConfig()
     {
-        $attributes = array();
-        $options    = array();
-        $store      = $this->getCurrentStore();
-        $taxHelper  = Mage::helper('tax');
+        // Inject collect options labels before parent's job
+        $this->collectOptionLabels();
+
+        // Then let parent do the job
+        return parent::getJsonConfig();
+    }
+
+    protected function collectOptionLabels()
+    {
+        $store = $this->getCurrentStore();
         $currentProduct = $this->getProduct();
 
-        $preconfiguredFlag = $currentProduct->hasPreconfiguredValues();
-        if ($preconfiguredFlag) {
-            $preconfiguredValues = $currentProduct->getPreconfiguredValues();
-            $defaultValues       = array();
-        }
-		
-		/* Wigman: Let's fetch all attribute labels for this product */
-		$configAttributes = Mage::getResourceModel('configurableswatches/catalog_product_attribute_super_collection')
-            ->addParentProductsFilter(array($currentProduct->getId()))
-            ->attachEavAttributes()
-            ->setStoreId($store->getId())
-        ;
-		
-		/* Wigman: and then store them into an array for reference */
+        /* Wigman: Let's fetch all attribute labels for this product */
+        $configAttributes = Mage::getResourceModel('configurableswatches/catalog_product_attribute_super_collection')
+        ->addParentProductsFilter(array($currentProduct->getId()))
+        ->attachEavAttributes()
+        ->setStoreId($store->getId());
+
+        /* Wigman: and then store them into an array for reference */
         $optionLabels = array();
         foreach ($configAttributes as $attr) {
             $optionLabels += $attr->getOptionLabels();
         }
-		
-        foreach ($this->getAllowProducts() as $product) {
-            $productId  = $product->getId();
 
-            foreach ($this->getAllowAttributes() as $attribute) {
-                $productAttribute   = $attribute->getProductAttribute();
-                $productAttributeId = $productAttribute->getId();
-                $attributeValue     = $product->getData($productAttribute->getAttributeCode());
-                if (!isset($options[$productAttributeId])) {
-                    $options[$productAttributeId] = array();
-                }
-
-                if (!isset($options[$productAttributeId][$attributeValue])) {
-                    $options[$productAttributeId][$attributeValue] = array();
-                }
-                $options[$productAttributeId][$attributeValue][] = $productId;
-            }
-        }
-
-        $this->_resPrices = array(
-            $this->_preparePrice($currentProduct->getFinalPrice())
-        );
-
-        foreach ($this->getAllowAttributes() as $attribute) {
-	        
-            $productAttribute = $attribute->getProductAttribute();
-            $attributeId = $productAttribute->getId();
-            $info = array(
-               'id'        => $productAttribute->getId(),
-               'code'      => $productAttribute->getAttributeCode(),
-               'label'     => $attribute->getLabel(),
-               'options'   => array()
-            );
-
-            $optionPrices = array();
-            $prices = $attribute->getPrices();
-            if (is_array($prices)) {
-                foreach ($prices as $value) {
-                    if(!$this->_validateAttributeValue($attributeId, $value, $options)) {
-                        continue;
-                    }
-                    $currentProduct->setConfigurablePrice(
-                        $this->_preparePrice($value['pricing_value'], $value['is_percent'])
-                    );
-                    $currentProduct->setParentId(true);
-                    Mage::dispatchEvent(
-                        'catalog_product_type_configurable_price',
-                        array('product' => $currentProduct)
-                    );
-                    $configurablePrice = $currentProduct->getConfigurablePrice();
-
-                    if (isset($options[$attributeId][$value['value_index']])) {
-                        $productsIndex = $options[$attributeId][$value['value_index']];
-                    } else {
-                        $productsIndex = array();
-                    }
-
-                    $info['options'][] = array(
-                        'id'        => $value['value_index'],
-                        'label'     => $value['label'],
-                        'price'     => $configurablePrice,
-                        'oldPrice'  => $this->_prepareOldPrice($value['pricing_value'], $value['is_percent']),
-                        'products'  => $productsIndex,
-                        'sort_id'   => $optionLabels[$value['value_index']][0]['sort_id'], //Wigman: we added the sort_id we retrieved above
-                    );
-                    $optionPrices[] = $configurablePrice;
-                }
-            }
-			
-			usort($info['options'], function($a, $b){ //Wigman: then finally we sort the attribute options array by sort_id
-				return $a['sort_id'] - $b['sort_id'];
-			});
-			
-            /**
-             * Prepare formated values for options choose
-             */
-            foreach ($optionPrices as $optionPrice) {
-                foreach ($optionPrices as $additional) {
-                    $this->_preparePrice(abs($additional-$optionPrice));
-                }
-            }
-            if($this->_validateAttributeInfo($info)) {
-               $attributes[$attributeId] = $info;
-            }
-
-            // Add attribute default value (if set)
-            if ($preconfiguredFlag) {
-                $configValue = $preconfiguredValues->getData('super_attribute/' . $attributeId);
-                if ($configValue) {
-                    $defaultValues[$attributeId] = $configValue;
-                }
-            }
-        }
-
-        $taxCalculation = Mage::getSingleton('tax/calculation');
-        if (!$taxCalculation->getCustomer() && Mage::registry('current_customer')) {
-            $taxCalculation->setCustomer(Mage::registry('current_customer'));
-        }
-
-        $_request = $taxCalculation->getDefaultRateRequest();
-        $_request->setProductClassId($currentProduct->getTaxClassId());
-        $defaultTax = $taxCalculation->getRate($_request);
-
-        $_request = $taxCalculation->getRateRequest();
-        $_request->setProductClassId($currentProduct->getTaxClassId());
-        $currentTax = $taxCalculation->getRate($_request);
-
-        $taxConfig = array(
-            'includeTax'        => $taxHelper->priceIncludesTax(),
-            'showIncludeTax'    => $taxHelper->displayPriceIncludingTax(),
-            'showBothPrices'    => $taxHelper->displayBothPrices(),
-            'defaultTax'        => $defaultTax,
-            'currentTax'        => $currentTax,
-            'inclTaxTitle'      => Mage::helper('catalog')->__('Incl. Tax')
-        );
-
-        $config = array(
-            'attributes'        => $attributes,
-            'template'          => str_replace('%s', '#{price}', $store->getCurrentCurrency()->getOutputFormat()),
-            'basePrice'         => $this->_registerJsPrice($this->_convertPrice($currentProduct->getFinalPrice())),
-            'oldPrice'          => $this->_registerJsPrice($this->_convertPrice($currentProduct->getPrice())),
-            'productId'         => $currentProduct->getId(),
-            'chooseText'        => Mage::helper('catalog')->__('Choose an Option...'),
-            'taxConfig'         => $taxConfig
-        );
-
-        if ($preconfiguredFlag && !empty($defaultValues)) {
-            $config['defaultValues'] = $defaultValues;
-        }
-
-        $config = array_merge($config, $this->_getAdditionalConfig());
-
-        return Mage::helper('core')->jsonEncode($config);
+        $this->_optionLabels = $optionLabels;
     }
-    
+
+    // Implement sorting of labels inside validate because its cool
+    protected function _validateAttributeInfo(&$info)
+    {
+        $ret = parent::_validateAttributeInfo($info);
+        // Dont loose time if not vaid
+        if($ret){
+
+            // traverse info and append sort
+            foreach($info['options'] as &$option){
+                $option['sort_id'] = $this->_optionLabels[$option['id']][0]['sort_id'];
+                $test ='';
+            }
+            //Wigman: then finally we sort the attribute options array by sort_id
+            usort($info['options'], function ($a, $b) {
+                return $a['sort_id'] - $b['sort_id'];
+            });
+
+        }
+        return $ret;
+    }
+
+
 }

--- a/app/code/community/Wigman/AjaxSwatches/Block/Catalog/Product/View/Type/Configurable/Abstract.php
+++ b/app/code/community/Wigman/AjaxSwatches/Block/Catalog/Product/View/Type/Configurable/Abstract.php
@@ -1,0 +1,6 @@
+<?php
+if ((string)Mage::getConfig()->getModuleConfig('OrganicInternet_SimpleConfigurableProducts')->active == 'true'){
+    class Wigman_AjaxSwatches_Block_Catalog_Product_View_Type_Configurable_Abstract extends OrganicInternet_SimpleConfigurableProducts_Catalog_Block_Product_View_Type_Configurable {}
+} else {
+    class Wigman_AjaxSwatches_Block_Catalog_Product_View_Type_Configurable_Abstract extends Mage_Catalog_Block_Product_View_Type_Configurable {}
+}


### PR DESCRIPTION
Overriding the whole Wigman_AjaxSwatches_Block_Catalog_Product_View_Type_Configurable::getJsonConfig method is not acceptable to be compliant with SCP.

Refactor to let parent's getJsonConfig() intact
- collectOptionLabels in isolated method
- apply sort only when needed in _validateAttributeInfo()
- Inherit from an abstract class that inherits from Mage or SCP if enabled (MageWorks's Method for rewrite conflict : best found ever!)
