### PR TITLE
Cleaning up indentation, spacing & dead code

### DIFF
--- a/app/code/community/Wigman/AjaxSwatches/Block/Catalog/Media/Js/List.php
+++ b/app/code/community/Wigman/AjaxSwatches/Block/Catalog/Media/Js/List.php
@@ -1,44 +1,18 @@
 <?php
-/**
- * Magento
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade Magento to newer
- * versions in the future. If you wish to customize Magento for your
- * needs please refer to http://www.magento.com for more information.
- *
- * @category    Mage
- * @package     Mage_ConfigurableSwatches
- * @copyright  Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
- * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
- */
 class Wigman_AjaxSwatches_Block_Catalog_Media_Js_List extends Mage_ConfigurableSwatches_Block_Catalog_Media_Js_List
 {
-	
-	protected function _construct() {
-		parent::_construct();
-	}
-	
+    protected function _construct()
+    {
+        parent::_construct();
+    }
+
     protected function _isCacheActive()
     {
-
         /* if there are any messages dont read from cache to show them */
         if (Mage::getSingleton('core/session')->getMessages(true)->count() > 0) {
             return false;
         }
         return true;
-
     }
 
     public function getCacheLifetime()
@@ -64,7 +38,6 @@ class Wigman_AjaxSwatches_Block_Catalog_Media_Js_List extends Mage_ConfigurableS
         return $cacheKey;
     }
 
-
     public function getCacheTags()
     {
         if (!$this->_isCacheActive()) {
@@ -73,10 +46,9 @@ class Wigman_AjaxSwatches_Block_Catalog_Media_Js_List extends Mage_ConfigurableS
         $cacheTags = array(
             Mage_Catalog_Model_Product::CACHE_TAG,
             Mage_Catalog_Model_Product::CACHE_TAG."_".$this->getPid()
-		);
+        );
 
         return $cacheTags;
-
     }
 
 }

--- a/app/code/community/Wigman/AjaxSwatches/Block/Catalog/Product/View/Type/Configurable.php
+++ b/app/code/community/Wigman/AjaxSwatches/Block/Catalog/Product/View/Type/Configurable.php
@@ -1,36 +1,10 @@
 <?php
-/*/**
- * Magento
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade Magento to newer
- * versions in the future. If you wish to customize Magento for your
- * needs please refer to http://www.magento.com for more information.
- *
- * @category    Mage
- * @package     Mage_Catalog
- * @copyright  Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
- * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
- */
-
-
 /**
  * Catalog super product configurable part block
  *
  * @category   Mage
  * @package    Mage_Catalog
- * @author      Magento Core Team <core@magentocommerce.com>
+ * @author     Magento Core Team <core@magentocommerce.com>
  *
  *
  * Wigman changes: We're adding attribute sorting to the mix! See comments below.
@@ -38,7 +12,6 @@
  */
 class Wigman_AjaxSwatches_Block_Catalog_Product_View_Type_Configurable extends Wigman_AjaxSwatches_Block_Catalog_Product_View_Type_Configurable_Abstract
 {
-
     protected $_optionLabels = null;
 
     public function getJsonConfig()
@@ -90,6 +63,4 @@ class Wigman_AjaxSwatches_Block_Catalog_Product_View_Type_Configurable extends W
         }
         return $ret;
     }
-
-
 }

--- a/app/code/community/Wigman/AjaxSwatches/Block/Swatchlist.php
+++ b/app/code/community/Wigman/AjaxSwatches/Block/Swatchlist.php
@@ -1,75 +1,73 @@
 <?php
 class Wigman_AjaxSwatches_Block_Swatchlist extends Mage_Core_Block_Template
 {
-	public $product, $products;
-	
-	protected function _construct() {
-		parent::_construct();
-	}
-	
-	protected function _toHtml() {
-	
-		$pid = $this->getPid();
-		
-		$storeId = Mage::App()->getStore()->getId();
-		
-		$collection = Mage::getModel('catalog/product')->setStoreId($storeId)->getCollection()
-		   ->addAttributeToSelect('*')
-		   ->addAttributeToFilter('entity_id', $pid)
-		   ->addStoreFilter($storeId)
-		   ->load();
-	
-	    /* @var $helper Mage_ConfigurableSwatches_Helper_Mediafallback */
-	    $helper = Mage::helper('configurableswatches/mediafallback');
-		
-	    if ($collection
-	        instanceof Mage_ConfigurableSwatches_Model_Resource_Catalog_Product_Type_Configurable_Product_Collection) {
-	        // avoid recursion
-	        return;
-	    }
-	
-	    $products = $collection->getItems();
-		
-	    $helper->attachChildrenProducts($products, $collection->getStoreId());
-	
-	    $helper->attachConfigurableProductChildrenAttributeMapping($products, $collection->getStoreId());
-	
-	    $helper->attachGallerySetToCollection($products, $collection->getStoreId());
-		
-		/* @var $product Mage_Catalog_Model_Product */
-		foreach ($products as $product) { //only runs once
-			$helper->groupMediaGalleryImages($product);
-			Mage::helper('configurableswatches/productimg')
-			    ->indexProductImages($product, $product->getListSwatchAttrValues());
+    public $product, $products;
 
-			$this->product = $product;
-		}	
-		
-		$this->products = $products;
-		
-		return parent::_toHtml();
-	}
-	
-	public function getCollection()
+    protected function _construct() {
+        parent::_construct();
+    }
+
+    protected function _toHtml() {
+
+        $pid = $this->getPid();
+
+        $storeId = Mage::App()->getStore()->getId();
+
+        $collection = Mage::getModel('catalog/product')->setStoreId($storeId)->getCollection()
+           ->addAttributeToSelect('*')
+           ->addAttributeToFilter('entity_id', $pid)
+           ->addStoreFilter($storeId)
+           ->load();
+
+        /* @var $helper Mage_ConfigurableSwatches_Helper_Mediafallback */
+        $helper = Mage::helper('configurableswatches/mediafallback');
+
+        if ($collection
+            instanceof Mage_ConfigurableSwatches_Model_Resource_Catalog_Product_Type_Configurable_Product_Collection) {
+            // avoid recursion
+            return;
+        }
+
+        $products = $collection->getItems();
+
+        $helper->attachChildrenProducts($products, $collection->getStoreId());
+
+        $helper->attachConfigurableProductChildrenAttributeMapping($products, $collection->getStoreId());
+
+        $helper->attachGallerySetToCollection($products, $collection->getStoreId());
+
+        /* @var $product Mage_Catalog_Model_Product */
+        foreach ($products as $product) { //only runs once
+            $helper->groupMediaGalleryImages($product);
+            Mage::helper('configurableswatches/productimg')
+                ->indexProductImages($product, $product->getListSwatchAttrValues());
+
+            $this->product = $product;
+        }
+
+        $this->products = $products;
+
+        return parent::_toHtml();
+    }
+
+    public function getCollection()
     {
 
-		return $this->products;
-	}
-	
+        return $this->products;
+    }
+
     public function getProduct()
     {
-	    return $this->product;
-	}
+        return $this->product;
+    }
 
     protected function _isCacheActive()
     {
-
         /* if there are any messages dont read from cache to show them */
         if (Mage::getSingleton('core/session')->getMessages(true)->count() > 0) {
             return false;
         }
         return true;
-
     }
 
     public function getCacheLifetime()
@@ -84,17 +82,15 @@ class Wigman_AjaxSwatches_Block_Swatchlist extends Mage_Core_Block_Template
         if (!$this->_isCacheActive()) {
             parent::getCacheKey();
         }
-		//Mage::log($this->getPid());
         $cacheKey = 'SwatchList_'.
             /* Create different caches for different categories */
             $this->getPid().'_'.
             /* ... stores */
             Mage::App()->getStore()->getCode().'_'.
             '';
-  
+
         return $cacheKey;
     }
-
 
     public function getCacheTags()
     {
@@ -107,7 +103,6 @@ class Wigman_AjaxSwatches_Block_Swatchlist extends Mage_Core_Block_Template
         );
 
         return $cacheTags;
-
     }
-    
+
 }

--- a/app/code/community/Wigman/AjaxSwatches/Helper/Mediafallback.php
+++ b/app/code/community/Wigman/AjaxSwatches/Helper/Mediafallback.php
@@ -1,35 +1,9 @@
 <?php
 /**
- * Magento
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade Magento to newer
- * versions in the future. If you wish to customize Magento for your
- * needs please refer to http://www.magento.com for more information.
- *
- * @category    Mage
- * @package     Mage_ConfigurableSwatches
- * @copyright  Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
- * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
- */
-
-/**
  * Class implementing the media fallback layer for swatches
  */
 class Wigman_AjaxSwatches_Helper_Mediafallback extends Mage_ConfigurableSwatches_Helper_Mediafallback
 {
-
     /**
      * Set child_attribute_label_mapping on products with attribute label -> product mapping
      * Depends on following product data:
@@ -78,7 +52,7 @@ class Wigman_AjaxSwatches_Helper_Mediafallback extends Mage_ConfigurableSwatches
                     if (!$childProduct->hasData($attribute->getAttributeCode())) {
                         continue;
                     }
-                    
+
                     if (!Mage::getStoreConfig('cataloginventory/options/show_out_of_stock') && !$childProduct->isSalable()) {
                         continue;
                     }
@@ -89,21 +63,21 @@ class Wigman_AjaxSwatches_Helper_Mediafallback extends Mage_ConfigurableSwatches
                     if (!isset($optionLabels[$optionId][0]['label'])) {
                         continue;
                     }
-					
+
                     // normalize to all lower case before we start using them
                     $optionLabels = array_map(function ($value) {
                         return array_map(function($key){
-	                        $key['label'] = trim(strtolower($key['label']));
-							return $key;
+                            $key['label'] = trim(strtolower($key['label']));
+                            return $key;
                         }, $value);
                     }, $optionLabels);
-					
+
                     // using default value as key unless store-specific label is present
                     $optionLabel = $optionLabels[$optionId][0]['label'];
                     $sortId = $optionLabels[$optionId][0]['sort_id'];
                     if (isset($optionLabels[$optionId][$storeId])) {
                         $optionLabel = $optionLabels[$optionId][$storeId]['label'];
-	                    $sortId = $optionLabels[$optionId][$storeId]['sort_id'];
+                        $sortId = $optionLabels[$optionId][$storeId]['sort_id'];
                     }
 
                     // initialize arrays if not present
@@ -130,14 +104,13 @@ class Wigman_AjaxSwatches_Helper_Mediafallback extends Mage_ConfigurableSwatches
             foreach ($mapping as $key => $value) {
                 $mapping[$key]['product_ids'] = array_unique($mapping[$key]['product_ids']);
             }
-            
+
             uasort($listSwatchValues, function($a, $b) use ($mapping) {
-				return $mapping[$a]['sort_id'] - $mapping[$b]['sort_id'];
-			});
+                return $mapping[$a]['sort_id'] - $mapping[$b]['sort_id'];
+            });
 
             $parentProduct->setChildAttributeLabelMapping($mapping)
                 ->setListSwatchAttrValues($listSwatchValues);
         } // end looping parent products
     }
-
 }

--- a/app/code/community/Wigman/AjaxSwatches/Helper/Productimg.php
+++ b/app/code/community/Wigman/AjaxSwatches/Helper/Productimg.php
@@ -1,35 +1,9 @@
 <?php
 /**
- * Magento
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade Magento to newer
- * versions in the future. If you wish to customize Magento for your
- * needs please refer to http://www.magento.com for more information.
- *
- * @category    Mage
- * @package     Mage_ConfigurableSwatches
- * @copyright  Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
- * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
- */
-
-/**
  * Class Mage_ConfigurableSwatches_Helper_Productimg
  */
 class Wigman_AjaxSwatches_Helper_Productimg extends Mage_ConfigurableSwatches_Helper_Productimg
 {
- 
     /**
      * Create the separated index of product images
      *
@@ -37,9 +11,9 @@ class Wigman_AjaxSwatches_Helper_Productimg extends Mage_ConfigurableSwatches_He
      * @param array|null $preValues
      * @return Mage_ConfigurableSwatches_Helper_Data
      *
-     * Wigman Changes: 
-     * -  we are now hiding products that sold out if this is set in admin (cataloginventory/options/show_out_of_stock), so we're missing these labels and skip those swatches accordingly in indexProductImages()
-     * - we changed the labels object to include sort_ids and need to adjust the references in filterImageInGallery() 
+     * Wigman Changes:
+     * - we are now hiding products that sold out if this is set in admin (cataloginventory/options/show_out_of_stock), so we're missing these labels and skip those swatches accordingly in indexProductImages()
+     * - we changed the labels object to include sort_ids and need to adjust the references in filterImageInGallery()
      *
      */
     public function indexProductImages($product, $preValues = null)
@@ -86,27 +60,27 @@ class Wigman_AjaxSwatches_Helper_Productimg extends Mage_ConfigurableSwatches_He
             foreach ($searchValues as $label) {
                 $imageKeys = array();
                 $swatchLabel = $label . self::SWATCH_LABEL_SUFFIX;
-				
-				if(isset($mapping[$label])){ //wigman add-on - after skipping the !isSalable colors, we don't have all the labels available
-                
-	                $imageKeys[$label] = array_search($label, $imageHaystack);
-	                if ($imageKeys[$label] === false) {
-	                    $imageKeys[$label] = array_search($mapping[$label]['default_label'], $imageHaystack);
-	                }
-	
-	                $imageKeys[$swatchLabel] = array_search($swatchLabel, $imageHaystack);
-	                if ($imageKeys[$swatchLabel] === false) {
-	                    $imageKeys[$swatchLabel] = array_search(
-	                        $mapping[$label]['default_label'] . self::SWATCH_LABEL_SUFFIX, $imageHaystack
-	                    );
-	                }
-	
-	                foreach ($imageKeys as $imageLabel => $imageKey) {
-	                    if ($imageKey !== false) {
-	                        $imageId = $mediaGallery['images'][$imageKey]['value_id'];
-	                        $images[$imageLabel] = $mediaGalleryImages->getItemById($imageId);
-	                    }
-	                }
+
+                if(isset($mapping[$label])){ //wigman add-on - after skipping the !isSalable colors, we don't have all the labels available
+
+                    $imageKeys[$label] = array_search($label, $imageHaystack);
+                    if ($imageKeys[$label] === false) {
+                        $imageKeys[$label] = array_search($mapping[$label]['default_label'], $imageHaystack);
+                    }
+
+                    $imageKeys[$swatchLabel] = array_search($swatchLabel, $imageHaystack);
+                    if ($imageKeys[$swatchLabel] === false) {
+                        $imageKeys[$swatchLabel] = array_search(
+                            $mapping[$label]['default_label'] . self::SWATCH_LABEL_SUFFIX, $imageHaystack
+                        );
+                    }
+
+                    foreach ($imageKeys as $imageLabel => $imageKey) {
+                        if ($imageKey !== false) {
+                            $imageId = $mediaGallery['images'][$imageKey]['value_id'];
+                            $images[$imageLabel] = $mediaGalleryImages->getItemById($imageId);
+                        }
+                    }
                 }
             }
             $this->_productImagesByLabel[$product->getId()] = $images;
@@ -130,18 +104,18 @@ class Wigman_AjaxSwatches_Helper_Productimg extends Mage_ConfigurableSwatches_He
         if (!isset($this->_productImageFilters[$product->getId()])) {
             $mapping = call_user_func_array("array_merge_recursive", $product->getChildAttributeLabelMapping());
 
-			/* Wigman: this goes out: */
-			//$filters = array_unique($mapping['labels']);
-			
-			/* Wigman: and this comes in (that's because we changed the labels object to include sort_ids) */
+            /* Wigman: this goes out: */
+            //$filters = array_unique($mapping['labels']);
+
+            /* Wigman: and this comes in (that's because we changed the labels object to include sort_ids) */
             $filters = array();
             foreach($mapping['labels'] as $index => $label){
-	            $filters[$index] = $label['label'];
+                $filters[$index] = $label['label'];
             }
 
             $filters = array_unique($filters);
-            
-            
+
+
             $filters = array_merge($filters, array_map(function ($label) {
                 return $label . Mage_ConfigurableSwatches_Helper_Productimg::SWATCH_LABEL_SUFFIX;
             }, $filters));

--- a/app/code/community/Wigman/AjaxSwatches/Model/Observer.php
+++ b/app/code/community/Wigman/AjaxSwatches/Model/Observer.php
@@ -1,28 +1,4 @@
 <?php
-/**
- * Magento
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade Magento to newer
- * versions in the future. If you wish to customize Magento for your
- * needs please refer to http://www.magento.com for more information.
- *
- * @category    Mage
- * @package     Mage_ConfigurableSwatches
- * @copyright  Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
- * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
- */
 class Wigman_AjaxSwatches_Model_Observer extends Mage_ConfigurableSwatches_Model_Observer
 {
     /**
@@ -33,10 +9,6 @@ class Wigman_AjaxSwatches_Model_Observer extends Mage_ConfigurableSwatches_Model
      */
     public function productListCollectionLoadAfter(Varien_Event_Observer $observer)
     {
-        
         return; // disable this entire functionality because it's slowwwwww
-        
-
     }
-
 }

--- a/app/code/community/Wigman/AjaxSwatches/Model/Resource/Catalog/Product/Attribute/Super/Collection.php
+++ b/app/code/community/Wigman/AjaxSwatches/Model/Resource/Catalog/Product/Attribute/Super/Collection.php
@@ -1,32 +1,7 @@
 <?php
-/**
- * Magento
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade Magento to newer
- * versions in the future. If you wish to customize Magento for your
- * needs please refer to http://www.magento.com for more information.
- *
- * @category    Mage
- * @package     Mage_ConfigurableSwatches
- * @copyright  Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
- * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
- */
 class Wigman_AjaxSwatches_Model_Resource_Catalog_Product_Attribute_Super_Collection
     extends Mage_ConfigurableSwatches_Model_Resource_Catalog_Product_Attribute_Super_Collection
 {
-
     /**
      * Load attribute option labels for current store and default (fallback)
      *

--- a/app/code/community/Wigman/AjaxSwatches/controllers/AjaxController.php
+++ b/app/code/community/Wigman/AjaxSwatches/controllers/AjaxController.php
@@ -22,8 +22,10 @@ class Wigman_AjaxSwatches_AjaxController extends Mage_Core_Controller_Front_Acti
             );
         }
 
-        $this->getResponse()->clearHeaders()->setHeader('Content-type','application/json',true);
-        $this->getResponse()->setBody(Mage::helper('core')->jsonEncode($_images));
+        $this->getResponse()
+            ->clearHeaders()
+            ->setHeader('Content-type','application/json',true);
+            ->setBody(Mage::helper('core')->jsonEncode($_images));
     }
 
     public function getlistdataAction()
@@ -67,7 +69,8 @@ class Wigman_AjaxSwatches_AjaxController extends Mage_Core_Controller_Front_Acti
                 ->toHtml();
         }
 
-        $this->getResponse()->clearHeaders()
+        $this->getResponse()
+            ->clearHeaders()
             ->setHeader('Content-type', 'application/json', true)
             ->setBody(Mage::helper('core')->jsonEncode($_response));
     }

--- a/app/code/community/Wigman/AjaxSwatches/controllers/AjaxController.php
+++ b/app/code/community/Wigman/AjaxSwatches/controllers/AjaxController.php
@@ -1,98 +1,74 @@
-<?php 
-class Wigman_AjaxSwatches_AjaxController extends Mage_Core_Controller_Front_Action {
+<?php
+class Wigman_AjaxSwatches_AjaxController extends Mage_Core_Controller_Front_Action
+{
+    public function updateAction()
+    {
+        $_pid = $this->getRequest()->getParam('pid');
+        if (! $_pid) throw new Exception();
 
-public function updateAction(){
+        $_product = Mage::getModel('catalog/product')->load($_pid);
 
+        $_imageHelper = Mage::helper('catalog/image');
 
-if(!Mage::app()->getRequest()->getParam('pid')) { return; }
+        $_images = array();
+        foreach ($_product->getMediaGalleryImages() as $_image) {
+            if ($_image['disabled_default']) continue;
 
-$pid = Mage::app()->getRequest()->getParam('pid');
+            $_imageFile = $_image->getFile();
 
-$_product = Mage::getModel('catalog/product')->load($pid);
-//get Product
+            $_images[] = array(
+                'thumb' => (string) $_imageHelper->init($_product, 'thumbnail', $_imageFile)->resize(75),
+                'image' => (string) $_imageHelper->init($_product, 'image', $_imageFile)
+            );
+        }
 
+        $this->getResponse()->clearHeaders()->setHeader('Content-type','application/json',true);
+        $this->getResponse()->setBody(Mage::helper('core')->jsonEncode($_images));
+    }
 
-$mediaImages= $_product->getMediaGalleryImages();
+    public function getlistdataAction()
+    {
+        $_request = $this->getRequest();
 
-$images = array();
-$i=1;
-foreach ($mediaImages as $_image){
-	//var_dump($image);
-	if(!$_image['disabled_default']){
-		
-		//echo Mage::helper('catalog/image')->init($_product, 'thumbnail', $_image->getFile())->resize(75);
-		$newImage = array(
-			'thumb' => (string) Mage::helper('catalog/image')->init($_product, 'thumbnail', $_image->getFile())->resize(75),
-			'image' => (string) Mage::helper('catalog/image')->init($_product, 'image', $_image->getFile())
-		);
-		
-		
-		$images[$i] = $newImage;
-		$i++;
-	} else {
-		//echo 'image disabled';
-	}
-	
-}
+        // check if functionality disabled
+        if (! Mage::helper('configurableswatches')->isEnabled()) {
+            throw new Exception('Configurable swatches disabled.');
+        }
 
+        $_pids = explode(',', $_request->getParam('pids'));
+        if (empty($_pids)) {
+            throw new Exception('Missing "pids" post parameter.');
+        }
 
-$this->getResponse()->clearHeaders()->setHeader('Content-type','application/json',true);
-$this->getResponse()->setBody(Mage::helper('core')->jsonEncode($images));
-return;	
+        $this->loadLayout();
 
-//return $images;
+        $_viewMode = ($_request->getParam('viewMode')) ? $_request->getParam('viewMode') : 'grid';
+        Mage::unregister('catViewKeepFrame');
+        Mage::register('catViewKeepFrame', $_viewMode == 'grid');
 
-}
+        $_response = array();
+        foreach ($_pids as $_pid) {
+            $_response['swatches'][] = array(
+                'id' => $_pid,
+                'value' => $this->getLayout()
+                    ->createBlock('Wigman_AjaxSwatches/swatchlist', "swatchlist-$_pid")
+                    ->setPid($_pid)
+                    ->setViewMode($_viewMode)
+                    ->setTemplate('configurableswatches/catalog/product/list/swatches.phtml')
+                    ->toHtml()
+            );
 
-public function getlistdataAction(){
+            $_response['jsons'][$_pid] = $this->getLayout()
+                ->createBlock('Wigman_AjaxSwatches/catalog_media_js_list', "mediajslist-$_pid")
+                ->setPid($_pid)
+                ->setViewMode($_viewMode)
+                ->setProductCollection($this->getLayout()->getBlock("swatchlist-$_pid")->getCollection())
+                ->setTemplate('wigman/ajaxswatches/media/js.phtml')
+                ->toHtml();
+        }
 
-if(!Mage::app()->getRequest()->getParam('pids')) { return; }
-
-if (!Mage::helper('configurableswatches')->isEnabled()) { // check if functionality disabled
-    return; // return without loading swatch functionality
-}
-
-$pids = explode(',',Mage::app()->getRequest()->getParam('pids'));
-
-$response = $swatches = $jsons = array();
-$this->loadLayout();
-
-$viewMode = (Mage::app()->getRequest()->getParam('viewMode'))? Mage::app()->getRequest()->getParam('viewMode') : 'grid';
-$keepFrame = ($viewMode == 'grid')? true : false;
-
-foreach($pids as $pid){
-	
-	Mage::unregister('catViewKeepFrame');
-	Mage::register('catViewKeepFrame',$keepFrame);
-	 	
-	 	
-	$swatches[] = array('id' => $pid, 'value' => $this->getLayout()
-				->createBlock('Wigman_AjaxSwatches/swatchlist','swatchlist-'.$pid)
-				->setPid($pid)
-				->setViewMode($viewMode)
-				->setTemplate('configurableswatches/catalog/product/list/swatches.phtml')
-				->toHtml());
-	
-	$productsCollection = $this->getLayout()->getBlock('swatchlist-'.$pid)->getCollection();
-	
-	//Mage::log($productsCollection);
-	
-	$jsons[$pid] = $this->getLayout()
-				->createBlock('Wigman_AjaxSwatches/catalog_media_js_list','mediajslist-'.$pid)
-				->setPid($pid)
-				->setViewMode($viewMode)
-				->setProductCollection($productsCollection)
-				->setTemplate('wigman/ajaxswatches/media/js.phtml')
-				->toHtml();
-					
-}
-		
-	    $response['swatches'] = $swatches;
-		
-		$response['jsons'] = $jsons;
-		
-		$this->getResponse()->clearHeaders()->setHeader('Content-type','application/json',true);
-		$this->getResponse()->setBody(Mage::helper('core')->jsonEncode($response));
-}
-
+        $this->getResponse()->clearHeaders()
+            ->setHeader('Content-type', 'application/json', true)
+            ->setBody(Mage::helper('core')->jsonEncode($_response));
+    }
 }

--- a/app/code/community/Wigman/AjaxSwatches/etc/config.xml
+++ b/app/code/community/Wigman/AjaxSwatches/etc/config.xml
@@ -1,70 +1,70 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
-	<modules>
-		<Wigman_AjaxSwatches>
-			<version>0.4.6</version>
-		</Wigman_AjaxSwatches>
-	</modules>
-	<global>
-		<blocks>
-			<Wigman_AjaxSwatches>
-				<class>Wigman_AjaxSwatches_Block</class>
-			</Wigman_AjaxSwatches>
-			<catalog>
+    <modules>
+        <Wigman_AjaxSwatches>
+            <version>0.4.6</version>
+        </Wigman_AjaxSwatches>
+    </modules>
+    <global>
+        <blocks>
+            <Wigman_AjaxSwatches>
+                <class>Wigman_AjaxSwatches_Block</class>
+            </Wigman_AjaxSwatches>
+            <catalog>
                 <rewrite>
                     <product_view_type_configurable>Wigman_AjaxSwatches_Block_Catalog_Product_View_Type_Configurable</product_view_type_configurable>
                 </rewrite>
-			</catalog>
-		</blocks>
-		<helpers>
-			<ajaxswatches>
+            </catalog>
+        </blocks>
+        <helpers>
+            <ajaxswatches>
                 <class>Wigman_AjaxSwatches_Helper</class>
                 <resourceModel>configurableswatches_resource</resourceModel>
             </ajaxswatches>
-			<ajaxswatches_resource>
-				<class>Wigman_AjaxSwatches_Model_Resource</class>
+            <ajaxswatches_resource>
+                <class>Wigman_AjaxSwatches_Model_Resource</class>
             </ajaxswatches_resource>
-			<configurableswatches>
-				<rewrite>
-					<mediafallback>Wigman_AjaxSwatches_Helper_Mediafallback</mediafallback>
-					<productimg>Wigman_AjaxSwatches_Helper_Productimg</productimg>
-				</rewrite>
-			</configurableswatches>
-		</helpers>
-		<models>
-		    <wigman_ajaxswatches>
-		        <class>Wigman_AjaxSwatches_Model</class>
+            <configurableswatches>
+                <rewrite>
+                    <mediafallback>Wigman_AjaxSwatches_Helper_Mediafallback</mediafallback>
+                    <productimg>Wigman_AjaxSwatches_Helper_Productimg</productimg>
+                </rewrite>
+            </configurableswatches>
+        </helpers>
+        <models>
+            <wigman_ajaxswatches>
+                <class>Wigman_AjaxSwatches_Model</class>
                 <resourceModel>configurableswatches_resource</resourceModel>
-		    </wigman_ajaxswatches>
-			<configurableswatches_resource>
-				<rewrite>
-					<catalog_product_attribute_super_collection>Wigman_AjaxSwatches_Model_Resource_Catalog_Product_Attribute_Super_Collection</catalog_product_attribute_super_collection>
-				</rewrite>
+            </wigman_ajaxswatches>
+            <configurableswatches_resource>
+                <rewrite>
+                    <catalog_product_attribute_super_collection>Wigman_AjaxSwatches_Model_Resource_Catalog_Product_Attribute_Super_Collection</catalog_product_attribute_super_collection>
+                </rewrite>
             </configurableswatches_resource>
-            
-		    <configurableswatches>
-		        <rewrite>
-		            <observer>Wigman_AjaxSwatches_Model_Observer</observer>
-		        </rewrite>
-		    </configurableswatches>
-		</models>
-	</global>
-	<frontend>
-		<routers>
-			<ajaxswatches>
-				<use>standard</use>
-				<args>
-					<module>Wigman_AjaxSwatches</module>
-					<frontName>ajaxswatches</frontName>
-				</args>
-			</ajaxswatches>
-		</routers>
-	    <layout>
-	        <updates>
-	            <ajaxswatches module="Wigman_AjaxSwatches">
-	                <file>wigman_ajaxswatches.xml</file>
-	            </ajaxswatches>
-	        </updates>
-	    </layout>
-	</frontend>
+
+            <configurableswatches>
+                <rewrite>
+                    <observer>Wigman_AjaxSwatches_Model_Observer</observer>
+                </rewrite>
+            </configurableswatches>
+        </models>
+    </global>
+    <frontend>
+        <routers>
+            <ajaxswatches>
+                <use>standard</use>
+                <args>
+                    <module>Wigman_AjaxSwatches</module>
+                    <frontName>ajaxswatches</frontName>
+                </args>
+            </ajaxswatches>
+        </routers>
+        <layout>
+            <updates>
+                <ajaxswatches module="Wigman_AjaxSwatches">
+                    <file>wigman_ajaxswatches.xml</file>
+                </ajaxswatches>
+            </updates>
+        </layout>
+    </frontend>
 </config>

--- a/app/design/frontend/base/default/layout/wigman_ajaxswatches.xml
+++ b/app/design/frontend/base/default/layout/wigman_ajaxswatches.xml
@@ -1,60 +1,31 @@
 <?xml version="1.0"?>
-<!--
-/**
- * Magento
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Academic Free License (AFL 3.0)
- * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade Magento to newer
- * versions in the future. If you wish to customize Magento for your
- * needs please refer to http://www.magento.com for more information.
- *
- * @category    design
- * @package     rwd_default
- * @copyright   Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
- * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- */
--->
 <layout version="0.1.0">
+    <product_list>
+        <reference name="product_list.after">
+            <remove name="configurableswatches.media.js.list" />
+        </reference>
 
-	<product_list>
-		<reference name="product_list.after">
-	            <remove name="configurableswatches.media.js.list" />
-		</reference>
-		
-		<reference name="product_list.swatches">
-        	<action method="setTemplate"><template>wigman/ajaxswatches/catalog/product/list/swatches.phtml</template></action>
-		</reference>
-    
-		<reference name="head">
-			<!-- add Js script to head -->
-	        <action method="addItem"><type>skin_js</type><name>wigman/ajaxswatches/js/swatches-extend.js</name><params/></action>
-	        <!-- add baseurl reference to head for use in JS -->
-	        <block type="core/template" name="baseurl" template="wigman/ajaxswatches/baseurl.phtml">
-		        <action method="setData"><name>active_swatch_selector</name><value><![CDATA[.swatch-current .value img]]></value></action>
-	        </block>
-		</reference>
-		
-	</product_list>
-	
+        <reference name="product_list.swatches">
+            <action method="setTemplate"><template>wigman/ajaxswatches/catalog/product/list/swatches.phtml</template></action>
+        </reference>
+
+        <reference name="head">
+            <!-- add Js script to head -->
+            <action method="addItem"><type>skin_js</type><name>wigman/ajaxswatches/js/swatches-extend.js</name><params/></action>
+            <!-- add baseurl reference to head for use in JS -->
+            <block type="core/template" name="baseurl" template="wigman/ajaxswatches/baseurl.phtml">
+                <action method="setData"><name>active_swatch_selector</name><value><![CDATA[.swatch-current .value img]]></value></action>
+            </block>
+        </reference>
+
+    </product_list>
+
     <PRODUCT_TYPE_configurable>
-		<reference name="head">
-			<!-- add Js script to head -->
-	        <action method="addItem"><type>skin_js</type><name>wigman/ajaxswatches/js/swatches-extend.js</name><params/></action>
-			<!-- add baseurl reference to head for use in JS -->
-	        <block type="core/template" name="baseurl" template="wigman/ajaxswatches/baseurl.phtml"/>
-		</reference>
+        <reference name="head">
+            <!-- add Js script to head -->
+            <action method="addItem"><type>skin_js</type><name>wigman/ajaxswatches/js/swatches-extend.js</name><params/></action>
+            <!-- add baseurl reference to head for use in JS -->
+            <block type="core/template" name="baseurl" template="wigman/ajaxswatches/baseurl.phtml"/>
+        </reference>
     </PRODUCT_TYPE_configurable>
-
-
 </layout>

--- a/app/design/frontend/base/default/template/wigman/ajaxswatches/baseurl.phtml
+++ b/app/design/frontend/base/default/template/wigman/ajaxswatches/baseurl.phtml
@@ -23,9 +23,8 @@
 
 <!-- save the sites baseurl for Ajax references -->
 <script lang="javascript">
-	var posturl = "<?php echo Mage::getUrl(''); ?>";
+    var posturl = "<?php echo Mage::getUrl(''); ?>";
 <?php if($this->getActiveSwatchSelector()){ ?>
-	var activeSwatchSelector = "<?php echo $this->getActiveSwatchSelector(); ?>";
+    var activeSwatchSelector = "<?php echo $this->getActiveSwatchSelector(); ?>";
 <?php } ?>
 </script>
-

--- a/app/design/frontend/base/default/template/wigman/ajaxswatches/catalog/product/list/swatches.phtml
+++ b/app/design/frontend/base/default/template/wigman/ajaxswatches/catalog/product/list/swatches.phtml
@@ -1,43 +1,16 @@
 <?php
-/**
- * Magento
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Academic Free License (AFL 3.0)
- * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade Magento to newer
- * versions in the future. If you wish to customize Magento for your
- * needs please refer to http://www.magento.com for more information.
- *
- * @category    design
- * @package     rwd_default
- * @copyright   Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
- * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- */
-?>
-<?php
 $_product = $this->getProduct();
 $configSwatchesListAttribute = Mage::getStoreConfig('configswatches/general/product_list_attribute',Mage::app()->getStore());
 
-if (Mage::helper('configurableswatches')->isEnabled() && $_product && $_product->getTypeID()=='configurable'){
+if (Mage::helper('configurableswatches')->isEnabled() && $_product && $_product->getTypeID()=='configurable') {
+    $_attributes = $_product->getTypeInstance(true)->getConfigurableAttributes($_product);
 
-	$_attributes = $_product->getTypeInstance(true)->getConfigurableAttributes($_product);
-
-	foreach($_attributes as $_attribute){
-    	if($_attribute->getAttributeId() == $configSwatchesListAttribute){
+    foreach ($_attributes as $_attribute) {
+        if ($_attribute->getAttributeId() == $configSwatchesListAttribute) {
 ?>
 <div class="swatch-loader" style="text-align:center;"><img src="<?php echo $this->getSkinUrl('wigman/ajaxswatches/images/ajax-loader.gif');?>" width="17" height="17" style="display:inline;" /></div>
-<?php		    
-	    }
+<?php
+        }
     }
 
 }

--- a/app/design/frontend/base/default/template/wigman/ajaxswatches/media/js.phtml
+++ b/app/design/frontend/base/default/template/wigman/ajaxswatches/media/js.phtml
@@ -1,30 +1,4 @@
 <?php
-/**
- * Magento
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Academic Free License (AFL 3.0)
- * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade Magento to newer
- * versions in the future. If you wish to customize Magento for your
- * needs please refer to http://www.magento.com for more information.
- *
- * @category    design
- * @package     rwd_default
- * @copyright   Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
- * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- */
-?>
-<?php
     /* @var $this Mage_ConfigurableSwatches_Block_Catalog_Media_Js_Abstract */
     $catViewKeepFrame = Mage::registry('catViewKeepFrame'); //Wigman: added for list/grid view support
 ?>

--- a/app/etc/modules/Wigman_AjaxSwatches.xml
+++ b/app/etc/modules/Wigman_AjaxSwatches.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
-<modules>
-<Wigman_AjaxSwatches>
-<active>true</active>
-<codePool>community</codePool>
-</Wigman_AjaxSwatches>
-</modules>
+    <modules>
+        <Wigman_AjaxSwatches>
+            <active>true</active>
+            <codePool>community</codePool>
+        </Wigman_AjaxSwatches>
+    </modules>
 </config>

--- a/skin/frontend/base/default/wigman/ajaxswatches/js/swatches-extend.js
+++ b/skin/frontend/base/default/wigman/ajaxswatches/js/swatches-extend.js
@@ -1,269 +1,246 @@
 $j(document).ready(function() {
+    (function(updateImage) {
+        ConfigurableMediaImages.updateImage = function (el) {
+            var select = $j(el);
+            var label = select.find('option:selected').attr('data-label');
+            var productId = optionsPrice.productId;
 
-	(function(updateImage) {
-	  ConfigurableMediaImages.updateImage = function (el) {
-  
-	        var select = $j(el);
-	        var label = select.find('option:selected').attr('data-label');
-	        var productId = optionsPrice.productId;
- 
-	        //find all selected labels
-	        var selectedLabels = new Array();
-	
-	        $j('.product-options .super-attribute-select').each(function() {
-	            var $option = $j(this);
-	            
-	            if($option.val() != '') {
-	                selectedLabels.push($option.find('option:selected').attr('data-label'));
-	            }
-	        });
-			
-	        
-	        var swatchImageUrl = ConfigurableMediaImages.getSwatchImage(productId, label, selectedLabels);
-	        if(ConfigurableMediaImages.isValidImage(swatchImageUrl)) {
-	            
-	            var swatchImage = ConfigurableMediaImages.getImageObject(productId, swatchImageUrl);
-	
-				ProductMediaManager.swapImage(swatchImage);
-		  
-	        }
-		  	
-		  	var pid = ConfigurableMediaImages.getSwatchProdId(productId, label, selectedLabels);
-			
-			if(!pid) { 
-				selectedLabels = new Array(selectedLabels[0]);
-				var pid = ConfigurableMediaImages.getSwatchProdId(productId, label, selectedLabels);
-			}
-			
-			if(!pid){
-	            return false;
-	        }
-		  
-	        $j.ajax({
-				url: posturl + 'ajaxswatches/ajax/update',
-				dataType: 'json',
-				type : 'post',
-				data: 'pid='+pid,
-				success: function(data){
-					if(data){
-						ConfigurableMediaImages.setMoreImages(data);
-					} else {
-						return true;
-					}
-				}
-			});
-			
-	      	
-	  };
-	}(ConfigurableMediaImages.updateImage));
-	
-	
+            //find all selected labels
+            var selectedLabels = new Array();
 
-	// extending the default getSwatchImage() function to get a fall-back PID when 
-	// more then 1 attribute is clicked and no match is found
-	(function(getSwatchImage) {
-	  ConfigurableMediaImages.getSwatchImage = function(productId, optionLabel, selectedLabels) {
-	
-        var fallback = ConfigurableMediaImages.productImages[productId];
-        if(!fallback) {
+            $j('.product-options .super-attribute-select').each(function() {
+                var $option = $j(this);
+
+                if ($option.val() != '') {
+                    selectedLabels.push($option.find('option:selected').attr('data-label'));
+                }
+            });
+
+
+            var swatchImageUrl = ConfigurableMediaImages.getSwatchImage(productId, label, selectedLabels);
+            if (ConfigurableMediaImages.isValidImage(swatchImageUrl)) {
+                var swatchImage = ConfigurableMediaImages.getImageObject(productId, swatchImageUrl);
+
+                ProductMediaManager.swapImage(swatchImage);
+            }
+
+            var pid = ConfigurableMediaImages.getSwatchProdId(productId, label, selectedLabels);
+
+            if (!pid) {
+                selectedLabels = new Array(selectedLabels[0]);
+                var pid = ConfigurableMediaImages.getSwatchProdId(productId, label, selectedLabels);
+            }
+
+            if (!pid) {
+                return false;
+            }
+
+            $j.ajax({
+                url: posturl + 'ajaxswatches/ajax/update',
+                dataType: 'json',
+                type : 'post',
+                data: 'pid='+pid,
+                success: function(data) {
+                    if (data) {
+                        ConfigurableMediaImages.setMoreImages(data);
+                    } else {
+                        return true;
+                    }
+                }
+            });
+        };
+    }(ConfigurableMediaImages.updateImage));
+
+    // extending the default getSwatchImage() function to get a fall-back PID when
+    // more then 1 attribute is clicked and no match is found
+    (function(getSwatchImage) {
+        ConfigurableMediaImages.getSwatchImage = function(productId, optionLabel, selectedLabels) {
+            var fallback = ConfigurableMediaImages.productImages[productId];
+            if (!fallback) {
+                return null;
+            }
+            //console.log(selectedLabels);
+
+            //first, try to get label-matching image on config product for this option's label
+            var currentLabelImage = fallback['option_labels'][optionLabel];
+            if (currentLabelImage && fallback['option_labels'][optionLabel]['configurable_product'][ConfigurableMediaImages.imageType]) {
+                //found label image on configurable product
+                return fallback['option_labels'][optionLabel]['configurable_product'][ConfigurableMediaImages.imageType];
+            }
+
+            var compatibleProducts = ConfigurableMediaImages.getCompatibleProductImages(fallback, selectedLabels);
+
+            //Wigman: try to get a fallback PID when no match found
+            if (compatibleProducts.length == 0) { //no compatible products
+                selectedLabels = new Array(selectedLabels[0]);
+                var compatibleProducts = ConfigurableMediaImages.getCompatibleProductImages(fallback, selectedLabels);
+            }
+
+            //Wigman: this is the original 'bail' when no PIDs found
+            if (compatibleProducts.length == 0) { //no compatible products
+                return null; //bail
+            }
+
+            //second, get any product which is compatible with currently selected option(s)
+            $j.each(fallback['option_labels'], function(key, value) {
+                var image = value['configurable_product'][ConfigurableMediaImages.imageType];
+                var products = value['products'];
+
+                if (image) { //configurable product has image in the first place
+                    //if intersection between compatible products and this label's products, we found a match
+                    var isCompatibleProduct = ConfigurableMediaImages.arrayIntersect(products, compatibleProducts).length > 0;
+                    if (isCompatibleProduct) {
+                        return image;
+                    }
+                }
+            });
+
+            //third, get image off of child product which is compatible
+            var childSwatchImage = null;
+            var childProductImages = fallback[ConfigurableMediaImages.imageType];
+            compatibleProducts.each(function(productId) {
+                if (childProductImages[productId] && ConfigurableMediaImages.isValidImage(childProductImages[productId])) {
+                    childSwatchImage = childProductImages[productId];
+                    return false; //break "loop"
+                }
+            });
+            if (childSwatchImage) {
+                return childSwatchImage;
+            }
+
+            //fourth, get base image off parent product
+            if (childProductImages[productId] && ConfigurableMediaImages.isValidImage(childProductImages[productId])) {
+                return childProductImages[productId];
+            }
+
+            //no fallback image found
             return null;
+        };
+    }(ConfigurableMediaImages.getSwatchImage));
+});
+
+ConfigurableMediaImages.ajaxLoadSwatchList = function() {
+    if (typeof(ConfigurableSwatchesList) != 'undefined') {
+        var items = $j('.products-grid li.item,.products-list li.item');
+        var i = 0;
+
+        //we allow the activeSwatch to be defined globally for compatibility with for example Mana filters (defined in wigman_ajaxswatches.xml)
+        if (typeof activeSwatchSelector === 'undefined') {
+            activeSwatchSelector = '.swatch-current .value img'; //default selector
         }
-		//console.log(selectedLabels);
-		
-        //first, try to get label-matching image on config product for this option's label
-        var currentLabelImage = fallback['option_labels'][optionLabel];
-        if(currentLabelImage && fallback['option_labels'][optionLabel]['configurable_product'][ConfigurableMediaImages.imageType]) {
-            //found label image on configurable product
-            return fallback['option_labels'][optionLabel]['configurable_product'][ConfigurableMediaImages.imageType];
-        }
+        var activeSwatch = $j(activeSwatchSelector);
 
-        var compatibleProducts = ConfigurableMediaImages.getCompatibleProductImages(fallback, selectedLabels);
+        var pids = [];
+        var viewMode = ($j('#products-list').length>0) ? 'list':'grid';
 
-		//Wigman: try to get a fallback PID when no match found
-        if(compatibleProducts.length == 0) { //no compatible products
-			selectedLabels = new Array(selectedLabels[0]);
-			var compatibleProducts = ConfigurableMediaImages.getCompatibleProductImages(fallback, selectedLabels);
-		}
-		
-		//Wigman: this is the original 'bail' when no PIDs found
-        if(compatibleProducts.length == 0) { //no compatible products
-            return null; //bail
-        }
+        items.find('.product-image img').each(function() {
+            var target = $j(this);
+            pids.push(target.attr('id').split('-').pop());
+        });
 
-        //second, get any product which is compatible with currently selected option(s)
-        $j.each(fallback['option_labels'], function(key, value) {
-            var image = value['configurable_product'][ConfigurableMediaImages.imageType];
-            var products = value['products'];
+        $j.ajax({
+            url: posturl + 'ajaxswatches/ajax/getlistdata',
+            dataType: 'json',
+            type : 'post',
+            data: 'pids='+pids.join(',')+'&viewMode='+viewMode,
+            success: function(data) {
+                if (data) {
 
-            if(image) { //configurable product has image in the first place
-                //if intersection between compatible products and this label's products, we found a match
-                var isCompatibleProduct = ConfigurableMediaImages.arrayIntersect(products, compatibleProducts).length > 0;
-                if(isCompatibleProduct) {
-                    return image;
+                    if (data.swatches) {
+
+                        $j(data.swatches).each(function(key, swatchObj) {
+                            i++;
+                            // It's not valid HTML having multiple elements with same ID
+                            // but in some cases there are same products on one page (e.g. top seller slider)
+                            var parentLi = $j('[id="product-collection-image-' + swatchObj['id'] + '"]').parentsUntil('ul,ol');
+
+                            //$j(swatchObj['value']).insertAfter(parentLi.find('.product-name'));
+                            parentLi.find('.swatch-loader').replaceWith($j(swatchObj['value']));
+                            if (i == items.length) {
+                                if (activeSwatch.length) {
+
+                                    items.find(".configurable-swatch-list li[data-option-label='"+activeSwatch.attr('title')
+                                        .toLowerCase()+"']")
+                                        .addClass('filter-match');
+
+                                }
+                                ConfigurableMediaImages.ajaxInit(data.jsons);
+                            }
+                        })
+                    }
+                } else {
+                    //return false;
                 }
             }
         });
-
-        //third, get image off of child product which is compatible
-        var childSwatchImage = null;
-        var childProductImages = fallback[ConfigurableMediaImages.imageType];
-        compatibleProducts.each(function(productId) {
-            if(childProductImages[productId] && ConfigurableMediaImages.isValidImage(childProductImages[productId])) {
-                childSwatchImage = childProductImages[productId];
-                return false; //break "loop"
-            }
-        });
-        if (childSwatchImage) {
-            return childSwatchImage;
-        }
-
-        //fourth, get base image off parent product
-        if (childProductImages[productId] && ConfigurableMediaImages.isValidImage(childProductImages[productId])) {
-            return childProductImages[productId];
-        }
-
-        //no fallback image found
-        return null;
-    };
-	}(ConfigurableMediaImages.getSwatchImage));
-	
-});
-
-ConfigurableMediaImages.ajaxLoadSwatchList = function(){
-	
-	if(typeof(ConfigurableSwatchesList) != 'undefined'){
-			
-		var items = $j('.products-grid li.item,.products-list li.item');
-		var i = 0;
-		
-		//we allow the activeSwatch to be defined globally for compatibility with for example Mana filters (defined in wigman_ajaxswatches.xml)
-		if(typeof activeSwatchSelector === 'undefined'){ 			
-			activeSwatchSelector = '.swatch-current .value img'; //default selector
-		}
-		var activeSwatch = $j(activeSwatchSelector);
-		
-		var pids = [];
-		var viewMode = ($j('#products-list').length>0) ? 'list':'grid';
-		
-		items.find('.product-image img').each(function(){
-			
-			var target = $j(this);
-			pids.push(target.attr('id').split('-').pop());
-			
-		});
-		
-		$j.ajax({
-				url: posturl + 'ajaxswatches/ajax/getlistdata',
-				dataType: 'json',
-				type : 'post',
-				data: 'pids='+pids.join(',')+'&viewMode='+viewMode,
-				success: function(data){
-					if(data){
-
-						if(data.swatches){
-
-							$j(data.swatches).each(function(key, swatchObj){
-								i++;
-								// It's not valid HTML having multiple elements with same ID
-								// but in some cases there are same products on one page (e.g. top seller slider)
-								var parentLi = $j('[id="product-collection-image-' + swatchObj['id'] + '"]').parentsUntil('ul,ol');
-								
-								//$j(swatchObj['value']).insertAfter(parentLi.find('.product-name'));
-								parentLi.find('.swatch-loader').replaceWith($j(swatchObj['value']));
-								if(i == items.length){
-									if(activeSwatch.length){
-									
-										items.find(".configurable-swatch-list li[data-option-label='"+activeSwatch.attr('title')
-											.toLowerCase()+"']")
-											.addClass('filter-match');
-										
-									}
-									ConfigurableMediaImages.ajaxInit(data.jsons);
-								}
-							})	
-						}
-					} else {
-						//return false;
-					}
-				}
-			});
-		
     }
 }
 
 $j(document).on('product-media-loaded', function() {
-
-	ConfigurableMediaImages.ajaxLoadSwatchList();
-    
+    ConfigurableMediaImages.ajaxLoadSwatchList();
 });
-    
-ConfigurableMediaImages.ajaxInit = function(jsons){
 
-	ConfigurableMediaImages.init('small_image');
+ConfigurableMediaImages.ajaxInit = function(jsons) {
+    ConfigurableMediaImages.init('small_image');
 
-	for (var key in jsons) {
-		ConfigurableMediaImages.setImageFallback(key, $j.parseJSON(jsons[key]));
-	}
+    for (var key in jsons) {
+        ConfigurableMediaImages.setImageFallback(key, $j.parseJSON(jsons[key]));
+    }
 
-	$j(document).trigger('configurable-media-images-init', ConfigurableMediaImages);
+    $j(document).trigger('configurable-media-images-init', ConfigurableMediaImages);
 }
 
 
-ConfigurableMediaImages.setMoreImages = function(data){
-	
-	var newImages = Array();
-	var maxId = 0;
-	
-	var thumblist = $j('.product-image-thumbs');
-	var gallery   =	$j('.product-image-gallery');
-	
-	thumblist.find('li').each(function(){ //removing current thumbs and large images
-		$j('#image-'+$j(this).find('a').data('image-index')).remove();
-		$j(this).remove();
-	});
-	
-	$j.each(data, function(key, value){ //adding new images
-		
-		maxId++;
+ConfigurableMediaImages.setMoreImages = function(data) {
+    var newImages = Array();
+    var maxId = 0;
 
-		thumblist.append('<li><a class="thumb-link" href="#" title data-image-index="'+maxId+'"><img src="'+value['thumb']+'" width="75" height="75" alt=""></a></li>');
-		gallery.append('<img id="image-'+maxId+'" class="gallery-image" src="'+value['image']+'" data-zoom-image="'+value['image']+'">');
-	});
-	ProductMediaManager.wireThumbnails();
+    var thumblist = $j('.product-image-thumbs');
+    var gallery   = $j('.product-image-gallery');
 
+    thumblist.find('li').each(function() { //removing current thumbs and large images
+        $j('#image-'+$j(this).find('a').data('image-index')).remove();
+        $j(this).remove();
+    });
+
+    $j.each(data, function(key, value) { //adding new images
+        maxId++;
+
+        thumblist.append('<li><a class="thumb-link" href="#" title data-image-index="'+maxId+'"><img src="'+value['thumb']+'" width="75" height="75" alt=""></a></li>');
+        gallery.append('<img id="image-'+maxId+'" class="gallery-image" src="'+value['image']+'" data-zoom-image="'+value['image']+'">');
+    });
+    ProductMediaManager.wireThumbnails();
 }
-
 
 ConfigurableMediaImages.getSwatchProdId = function(productId, optionLabel, selectedLabels) {
-        var fallback = ConfigurableMediaImages.productImages[productId];
-        if(!fallback) {
-            return null;
-        }
-
-		var compatibleProducts = ConfigurableMediaImages.getCompatibleProductImages(fallback, selectedLabels);
-
-        if(compatibleProducts.length == 0) { //no compatible products
-            return null; //bail
-        }
-
-
-        var childSwatchProdId = null;
-        var childProductImages = fallback[ConfigurableMediaImages.imageType];
-        compatibleProducts.each(function(productId) {
-            if(childProductImages[productId] && ConfigurableMediaImages.isValidImage(childProductImages[productId])) {
-                childSwatchProdId = productId;
-                return false; //break "loop"
-            }
-        });
-        if (childSwatchProdId) {
-            return childSwatchProdId;
-        }
-
-        //fourth, get base image off parent product
-        if (childProductImages[productId] && ConfigurableMediaImages.isValidImage(childProductImages[productId])) {
-            return productId;
-        }
-
-        //no prodId found
+    var fallback = ConfigurableMediaImages.productImages[productId];
+    if (!fallback) {
         return null;
+    }
+
+    var compatibleProducts = ConfigurableMediaImages.getCompatibleProductImages(fallback, selectedLabels);
+
+    if (compatibleProducts.length == 0) { //no compatible products
+        return null; //bail
+    }
+
+    var childSwatchProdId = null;
+    var childProductImages = fallback[ConfigurableMediaImages.imageType];
+    compatibleProducts.each(function(productId) {
+        if (childProductImages[productId] && ConfigurableMediaImages.isValidImage(childProductImages[productId])) {
+            childSwatchProdId = productId;
+            return false; //break "loop"
+        }
+    });
+    if (childSwatchProdId) {
+        return childSwatchProdId;
+    }
+
+    //fourth, get base image off parent product
+    if (childProductImages[productId] && ConfigurableMediaImages.isValidImage(childProductImages[productId])) {
+        return productId;
+    }
+
+    //no prodId found
+    return null;
 }


### PR DESCRIPTION
_Note: I recommend reviewing the changes in split diff mode._

I have discovered a bug (issue #35) that I am currently working on resolving, but because it touches a good number of files, I have been stymied by the wildly inconsistent spacing and style across this module. This initial pull request does not change any functionality but makes the following improvements to match Magento module best practices/standards:
- Changes indentation to be consistently 4 spaces rather than tabs (was previously a mix).
- Removes old commented-out debug code.
- Removes core Magento copyright headers that do not apply.
- Slightly refactors `Wigman_AjaxSwatches_AjaxController` in the following ways:
  - Throws exceptions on errors rather than simply returning nothing so that error cases will be reported in logs.
  - Cleans up some code to be more succinct/readable (without changing actual functional logic).
