### PR TITLE
fatal errors when getOptionLabels() not array

### DIFF
--- a/app/code/community/Wigman/AjaxSwatches/Helper/Mediafallback.php
+++ b/app/code/community/Wigman/AjaxSwatches/Helper/Mediafallback.php
@@ -34,7 +34,9 @@ class Wigman_AjaxSwatches_Helper_Mediafallback extends Mage_ConfigurableSwatches
 
         $optionLabels = array();
         foreach ($configAttributes as $attribute) {
-            $optionLabels += $attribute->getOptionLabels();
+            if (is_array($attribute->getOptionLabels())) {
+                $optionLabels += $attribute->getOptionLabels();
+            }
         }
         foreach ($parentProducts as $parentProduct) {
             $mapping = array();


### PR DESCRIPTION
we have fatal errors when $attribute->getOptionLabels() return not array.
